### PR TITLE
add follow-btn.tsx component - resolves #24

### DIFF
--- a/components/molecules/client/follow-btn/component.tsx
+++ b/components/molecules/client/follow-btn/component.tsx
@@ -1,0 +1,26 @@
+import { Btn } from '@/components/atoms/btn';
+import { cn } from '@/lib/cn';
+
+interface Props
+  extends Omit<
+    React.ComponentProps<typeof Btn>,
+    'variant' | 'children' | 'href' | 'onClick'
+  > {
+    variant: 'follow' | 'unfollow' | 'following';
+  }
+
+export const FollowBtn: React.FC<Props> = ({variant, className, ...props}) => (
+    <Btn 
+    variant="secondary"
+    className={cn(
+        {
+            'text-light-primary': variant === 'follow',
+            'text-light-text': variant === 'following',
+            "text-[#CF0000]": variant === "unfollow",
+        },
+        className,
+    )}
+    >
+      {variant.charAt(0).toUpperCase() + variant.slice(1)}
+      </Btn>
+)

--- a/components/molecules/client/follow-btn/index.ts
+++ b/components/molecules/client/follow-btn/index.ts
@@ -1,0 +1,2 @@
+export { FollowBtn as default } from './component';
+export * from './component';


### PR DESCRIPTION
added the follow-btn.tsx component as a molecule that uses the btn component. 
Screenshot of what all three variants look like is added below.
"danger" (for the "unfollow" variant) was not a color that was set up in the tailwind theme, so I just added the color directly to the className, wasn't sure if I should add it to the tailwind theme instead

![Screenshot 2024-10-06 150400](https://github.com/user-attachments/assets/c6e7373d-36a4-4877-a4b0-cda98f235931)
